### PR TITLE
Fix single non zeroth index resolving

### DIFF
--- a/graphql_core_promise/execute/promise.py
+++ b/graphql_core_promise/execute/promise.py
@@ -460,7 +460,7 @@ class PromiseExecutionContext(ExecutionContext):
 
                 # If there is only one index, avoid the overhead of parallelization.
                 index = awaitable_indices[0]
-                return completed_results[0].then(on_one_resolved)
+                return completed_results[index].then(on_one_resolved)
 
             def on_all_resolve(results):
                 for index, result in zip(awaitable_indices, results, strict=False):


### PR DESCRIPTION
There is a bug on [this line](https://github.com/fellowapp/graphql-core-promise/blob/main/graphql_core_promise/execute/promise.py#L463). I believe it should be `return completed_results[index].then(on_one_resolved)` instead of `return completed_results[0].then(on_one_resolved)`

It looks like that code is optimizing for when there is only a single Promise being returned and tries to execute the 0th index of "awaitable_promise"s. However it is possible the awaitable index may not be the 0ths index, it could be the 1st.


Here is some sample code that reproduces the issue.

```
from graphene import List, ObjectType, Schema, String
from graphene.test import Client
from graphql_core_promise import PromiseExecutionContext
from promise import Promise
from promise.dataloader import DataLoader


class SomeLoader(DataLoader):
    def batch_load_fn(self, keys):
        return Promise.resolve([f"{key=} resolved!" for key in keys])


some_loader = SomeLoader()


class Query(ObjectType):
    some_field = List(String)

    def resolve_some_field(root, _):
        return ["Some string", some_loader.load(10), "Another string"]


schema = Schema(query=Query)


client = Client(schema=schema, execution_context_class=PromiseExecutionContext)

foo = client.execute("query myQuery { someField }")
print(foo)
```

Before:
```
{'errors': [{'message': "'str' object has no attribute 'then'", 'locations': [{'line': 1, 'column': 17}], 'path': ['someField']}], 'data': {'someField': None}}
```

After:
```
{'data': {'someField': ['Some string', 'key=10 resolved!', 'Another string']}}
```